### PR TITLE
docs: fix link titles of oauth flow models on pages for composables

### DIFF
--- a/docs/composables/use-code-client.md
+++ b/docs/composables/use-code-client.md
@@ -4,7 +4,7 @@ title: useCodeClient
 
 # useCodeClient
 
-Initiate login with [implicit flow](https://developers.google.com/identity/oauth2/web/guides/use-code-model) using code client. Return values of the composable can be used
+Initiate login with [auth code flow](https://developers.google.com/identity/oauth2/web/guides/use-code-model) using code client. Return values of the composable can be used
 to trigger the login flow and determine the readiness of the client.
 It also provides callbacks such as `onSuccess` and `onError` that can be used to obtain the results from the login client.
 

--- a/docs/composables/use-token-client.md
+++ b/docs/composables/use-token-client.md
@@ -4,7 +4,7 @@ title: useTokenClient
 
 # useTokenClient
 
-Initiate login with [authcode flow](https://developers.google.com/identity/oauth2/web/guides/use-token-model) using token client. Return values of the composable can be used
+Initiate login with [implicit grant flow](https://developers.google.com/identity/oauth2/web/guides/use-token-model) using token client. Return values of the composable can be used
 to trigger the login flow and determine the readiness of the client.
 It also provides callbacks such as `onSuccess` and `onError` that can be used to obtain the results from the login client.
 


### PR DESCRIPTION
The token client is used in implicit grant flow model and the code client in authorization code model. The urls in the documentation lead to the right places in Google's docs but their titles are mixed up.

As a side note the names of types are also mixed up, e.g. [here](https://github.com/wavezync/vue3-google-signin/blob/c99db657f036a9f9253036427a477a8a776a083d/src/composables/useCodeClient.ts#L15) it should be `AuthCodeSuccessResponse` not `ImplicitFlowSuccessResponse` etc. I don't think it can be fixed without introducing a breaking change since they are different and the problem is with naming only anyway, the types themselves are correct.