### PR TITLE
Add check for environment before debug logging

### DIFF
--- a/src/composables/useOneTap.ts
+++ b/src/composables/useOneTap.ts
@@ -219,14 +219,10 @@ export default function useOneTap(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       client_id: clientId!,
       callback: (credentialResponse: CredentialResponse) => {
-        if (process.env.NODE_ENV === 'development') {
-            console.log("cb triggered");
-        }
         if (!credentialResponse.clientId || !credentialResponse.credential) {
           onError?.();
           return;
         }
-        
         onSuccess?.(credentialResponse);
       },
       native_callback: (response: NativeCallbackResponse) => {

--- a/src/composables/useOneTap.ts
+++ b/src/composables/useOneTap.ts
@@ -219,12 +219,14 @@ export default function useOneTap(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       client_id: clientId!,
       callback: (credentialResponse: CredentialResponse) => {
-        console.log("cb triggered");
+        if (process.env.NODE_ENV === 'development') {
+            console.log("cb triggered");
+        }
         if (!credentialResponse.clientId || !credentialResponse.credential) {
           onError?.();
           return;
         }
-
+        
         onSuccess?.(credentialResponse);
       },
       native_callback: (response: NativeCallbackResponse) => {


### PR DESCRIPTION
This PR adds a check for the node env before outputting a console log when a callback is called.

Why? Currently this debug is called in all environments, including production.