### PR TITLE
Resolve TypeScript ES Environment Errors by Correcting 'module' and 'types' Fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue3-google-signin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue3-google-signin",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "devDependencies": {
         "@rushstack/eslint-patch": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
     "docs:serve": "vitepress serve docs"
   },
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.cjs.js",
+  "module": "./dist/index.es.js",
   "exports": {
     ".": {
       "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
+      "require": "./dist/index.umd.js",
+      "types": "./dist/plugin.d.ts"
     }
   },
   "types": "./dist/plugin.d.ts",


### PR DESCRIPTION
Changes:

1. Changed the `module` field to point to an ES file instead of a CJS file.
2. Added the `types` field under `exports > "."`


The root types path has been retained for backward compatibility. Please review and let me know if there are any issues. 
Thank you.