### PR TITLE
Bump: Main Package Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue3-google-signin",
   "type": "module",
-  "version": "1.3.2",
+  "version": "1.3.4",
   "description": "Google Sign-in for Vue3 with Google Identity Service",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
I have updated the version in the main package.(1.3.2 -> 1.3.4, 1.3.3 is already released) Once this PR is merged, I will pull again and push PR(https://github.com/wavezync/vue3-google-signin/pull/61).

One thing I'm curious about is whether it's correct for contributors to update the main package version themselves? It seems like it could be challenging to manage versions with multiple contributors. 🥲