### PR TITLE
Update google-signin-button default size

### DIFF
--- a/docs/components/google-signin-button.md
+++ b/docs/components/google-signin-button.md
@@ -120,7 +120,7 @@ This button renders default Google SignIn Button using Google API.
 ### size
 
 - **Type**: `"large" | "medium" | "small"`
-- **Default**: `small`
+- **Default**: `large`
 - [Read More](https://developers.google.com/identity/gsi/web/reference/js-reference#size)
 
   The button size


### PR DESCRIPTION
The button size default value is large. See https://developers.google.com/identity/gsi/web/reference/js-reference#size